### PR TITLE
feat: add public read-only endpoints and refactor pagination

### DIFF
--- a/src/main/java/com/dresscode/api_dresscode/config/SecurityConfig.java
+++ b/src/main/java/com/dresscode/api_dresscode/config/SecurityConfig.java
@@ -50,10 +50,18 @@ public class SecurityConfig {
                     .requestMatchers("/auth/**", "/api/auth/**").permitAll()
                     // Webhook — signature validated by WebhookSignatureFilter (not JWT)
                     .requestMatchers("/api/mercado-pago/webhook").permitAll()
+                    // Static files — product images (/uploads/**) and banner assets (/assets/**)
+                    .requestMatchers("/uploads/**", "/assets/**").permitAll()
                     // Public read-only resources
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,
-                        "/api/banners", "/api/banners/**"
+                        "/api/banners", "/api/banners/**",
+                        "/api/productos/**",
+                        "/api/categorias/**",
+                        "/api/tipos/**",
+                        "/api/talles/**",
+                        "/api/colores/active",
+                        "/api/marcas/active"
                     ).permitAll()
                     // Swagger / OpenAPI (accessible without auth for API docs)
                     .requestMatchers(

--- a/src/main/java/com/dresscode/api_dresscode/controllers/BaseController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/BaseController.java
@@ -23,7 +23,7 @@ public abstract class BaseController<E extends Base, ID extends Serializable> {
     }
 
     @GetMapping("/paged")
-    public ResponseEntity<?> getAll(Pageable pageable) throws Exception {
+    public ResponseEntity<?> getAllPaged(Pageable pageable) throws Exception {
         return ResponseEntity.ok(service.findAll(pageable));
     }
 

--- a/src/main/java/com/dresscode/api_dresscode/controllers/CategoriaController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/CategoriaController.java
@@ -43,5 +43,11 @@ public class CategoriaController extends BaseController<Categoria, Long> {
         return ResponseEntity.noContent().build();
     }
 
+    /** PATCH alias — frontend uses PATCH /categorias/{id}/status */
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> changeStatusPatch(@PathVariable Long id) throws Exception {
+        return super.changeStatus(id);
+    }
 
 }

--- a/src/main/java/com/dresscode/api_dresscode/controllers/ColorController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/ColorController.java
@@ -42,6 +42,13 @@ public class ColorController extends BaseController<Color, Long> {
         return super.changeStatus(id);
     }
 
+    /** PATCH alias — frontend uses PATCH /colores/{id}/status */
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> changeStatusPatch(@PathVariable Long id) throws Exception {
+        return super.changeStatus(id);
+    }
+
     @Override
     @PutMapping("/{id}/activate")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/dresscode/api_dresscode/controllers/MarcaController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/MarcaController.java
@@ -42,6 +42,13 @@ public class MarcaController extends BaseController<Marca, Long> {
         return super.changeStatus(id);
     }
 
+    /** PATCH alias — frontend uses PATCH /marcas/{id}/status */
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> changeStatusPatch(@PathVariable Long id) throws Exception {
+        return super.changeStatus(id);
+    }
+
     @Override
     @PutMapping("/{id}/activate")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/dresscode/api_dresscode/controllers/TalleController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/TalleController.java
@@ -37,4 +37,11 @@ public class TalleController extends BaseController<Talle,Long> {
         return ResponseEntity.noContent().build();
     }
 
+    /** PATCH alias — frontend uses PATCH /talles/{id}/status */
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> changeStatusPatch(@PathVariable Long id) throws Exception {
+        return super.changeStatus(id);
+    }
+
 }

--- a/src/main/java/com/dresscode/api_dresscode/controllers/TipoController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/TipoController.java
@@ -36,4 +36,11 @@ public class TipoController extends BaseController<Tipo, Long> {
         return ResponseEntity.ok(categorias);
     }
 
+    /** PATCH alias — frontend uses PATCH /tipos/{id}/status */
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> changeStatusPatch(@PathVariable Long id) throws Exception {
+        return super.changeStatus(id);
+    }
+
 }

--- a/src/main/java/com/dresscode/api_dresscode/controllers/UsuarioController.java
+++ b/src/main/java/com/dresscode/api_dresscode/controllers/UsuarioController.java
@@ -33,8 +33,8 @@ public class UsuarioController extends BaseController<Usuario, Long>{
     @Override
     @GetMapping("/paged")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> getAll(org.springframework.data.domain.Pageable pageable) throws Exception {
-        return super.getAll(pageable);
+    public ResponseEntity<?> getAllPaged(org.springframework.data.domain.Pageable pageable) throws Exception {
+        return super.getAllPaged(pageable);
     }
 
     @Override


### PR DESCRIPTION
- Habilitar GET público a productos, categorías, tipos, talles, colores activos, marcas activas
- Renombrar BaseController.getAll() a getAllPaged() para mayor claridad
- Actualizar todos los controllers dependientes al nuevo nombre de método
- Habilitar servicio de archivos estáticos para /uploads/** y /assets/**